### PR TITLE
RTcmixShell non-interactive mode

### DIFF
--- a/RTcmix_API.h
+++ b/RTcmix_API.h
@@ -35,6 +35,8 @@ extern "C" {
 		AudioFormat_32BitFloat = 16				// single-precision float samples, scaled between -32767.0 and 32767.0
 	} RTcmix_AudioFormat;
 	int RTcmix_setAudioBufferFormat(RTcmix_AudioFormat format, int nchans);
+    // Set this to 0 to run non-interactively (i.e., parse the score completely first, then start running audio).
+    void RTcmix_setInteractive(int interactive);
 	// Call this to send and receive audio from RTcmix
 	int RTcmix_runAudio(void *inAudioBuffer, void *outAudioBuffer, int nframes);
 #endif

--- a/audio.h
+++ b/audio.h
@@ -36,14 +36,14 @@ class Audio : public QObject
 public:
     Audio();
     ~Audio();
-    int reinitializeRTcmix();
+    int reinitializeRTcmix(bool interactive=false);
+    int startAudio();
     bool startRecording(const QString &);
     void stopRecording();
 
 private:
     int initializeAudio();
-    int initializeRTcmix();
-    int startAudio();
+    int initializeRTcmix(bool interactive=false);
     int stopAudio();
 
     // We use a static method wrapper for our callback to make portaudio work from C++,

--- a/main.cpp
+++ b/main.cpp
@@ -58,7 +58,7 @@
 #define APP_ORGANIZATION_NAME       "RTcmix"
 #define APP_ORGANIZATION_DOMAIN     "rtcmix.org"
 #define APP_NAME                    "RTcmixShell"
-#define APP_VERSION_STR             "1.0.9"
+#define APP_VERSION_STR             "1.1.0"
 
 int main(int argc, char *argv[])
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -39,6 +39,10 @@ MainWindow::MainWindow(QWidget *parent)
     createPreferences();
 
     audio = new Audio;
+    // Audio is only started up before score parsing if we are in Overlapping mode
+	if (scorePlayMode == Overlapping) {
+		audio->startAudio();
+	}
 
     createEditors();
     rtcmixLogView = new RTcmixLogView(this);
@@ -644,6 +648,7 @@ void MainWindow::checkScoreFinished()
 void MainWindow::setScorePlayMode()
 {
     if (actionAllowOverlappingScores->isChecked()) {
+//    	qDebug("setScorePlayMode: new mode is Overlapping");
         if (mainWindowPreferences->audioShowOverlappingScoresWarning()) {
             QMessageBox msgBox;
             msgBox.setText(tr("Playing scores simultaneously can be unstable. "
@@ -656,11 +661,22 @@ void MainWindow::setScorePlayMode()
             if (result == 0)
                 mainWindowPreferences->setAudioShowOverlappingScoresWarning(false);
         }
+        if (scorePlayMode == Exclusive) {
+            const bool interactive = true;
+            audio->reinitializeRTcmix(interactive);
+        }
         scorePlayMode = Overlapping;
+		audio->startAudio();
         // we do not disable the score-finished callback, in case
         // other useful information gets there in the future
     }
     else {
+//    	qDebug("setScorePlayMode: new mode is Exclusive");
+    	if (scorePlayMode == Overlapping) {
+    		const bool notInteractive = false;
+    		// Seems a bit drastic - maybe Audio::stopAudio should just be public?
+    		audio->reinitializeRTcmix(notInteractive);
+    	}
         scorePlayMode = Exclusive;
         // not sure we should stop score playing here; this setting
         // should affect future plays
@@ -722,6 +738,10 @@ void MainWindow::playScore()
             stopScoreNoReinit();        // no reinit, so we can see error in log
             reinitRTcmixOnPlay = true;
         }
+		// Audio is  started up after score parsing unless we are in Overlapping mode
+		else if (scorePlayMode == Exclusive) {
+			audio->startAudio();
+		}
     }
 //qDebug("invoked playScore(), buf len: %d, buffer...", len);
 //qDebug("%s", buf);
@@ -768,7 +788,12 @@ void MainWindow::stopScore()
 #ifdef FLUSH_SCORE_ON_STOP
     RTcmix_flushScore();
 #else
-    audio->reinitializeRTcmix();
+	const bool isInteractive = (scorePlayMode == Overlapping);
+    audio->reinitializeRTcmix(isInteractive);
+    // Audio is only started up before score parsing if we are in Overlapping mode
+	if (isInteractive) {
+		audio->startAudio();
+	}
 #endif
 }
 
@@ -782,11 +807,15 @@ void MainWindow::showClipping(int clipCount)
     //qDebug("MainWindow::showClipping(%d)", clipCount);
 }
 
-void MainWindow::reinitializeAudio()
+void MainWindow::reinitializeAudio()	// This is only called when preferences change
 {
     stopScoreNoReinit();
     delete audio;
     audio = new Audio;
+    // Audio is only started up before score parsing if we are in Overlapping mode
+	if (scorePlayMode == Overlapping) {
+		audio->startAudio();
+	}
 }
 
 bool MainWindow::chooseRecordFilename(QString &fileName)


### PR DESCRIPTION
RTcmixShell now runs in non-interactive mode by default.  This means that by default, the provided score is parsed by the system *prior to starting the audio stream*.  This eliminates the event timing issues which were caused by attempting to process a large score interactively.
